### PR TITLE
Removing download plan feature for now

### DIFF
--- a/public/js/directives/navbar/navbar-directive.html
+++ b/public/js/directives/navbar/navbar-directive.html
@@ -45,7 +45,7 @@
                 <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Plan<span class="caret"></span></a>
                 <ul class="dropdown-menu" role="menu">
-                    <li><a href="#" ng-click="download()">Download Plan</a></li>
+                    <li><a href="#"><strike style="cursor:not-allowed">Download Plan</strike></a></li>
                     <li><a href="#" ng-click="editColorscheme()">
                         <i class="fa fa-fw fa-paint-brush" aria-hidden="true"></i>Edit Colors</a>
                     </li>


### PR DESCRIPTION
Since the download plan feature doesn't really work, I disabled the option by removing the ng-click property and styling it with a strikethrough and not-allowed cursor. If we get time, we can add the feature back in when it is working correctly