### PR TITLE
Warning button styling

### DIFF
--- a/public/sass/colors.scss
+++ b/public/sass/colors.scss
@@ -11,3 +11,6 @@ $darker-green: #388E3C;
 $blue: #2196F3;
 $dark-blue: #1E88E5;
 $darker-blue: #1976D2;
+$orange: #FF9800;
+$dark-orange: #FB8C00;
+$darker-orange: #F57C00;

--- a/public/sass/style.scss
+++ b/public/sass/style.scss
@@ -66,3 +66,16 @@
 .btn-success:active {
   background-color: $darker-green;
 }
+
+.btn-warning {
+  background-color: $orange;
+  color: $text;
+}
+
+.btn-warning:hover {
+  background-color: $dark-orange;
+}
+
+.btn-warning:active {
+  background-color: $darker-orange;
+}


### PR DESCRIPTION
Noticed the cancel (warning) button needed styling when adding classes. This is a quick fix for that. 

![warning](https://cloud.githubusercontent.com/assets/9043915/24485678/0f2f6184-14d4-11e7-9450-cab6e1fd5bd3.png)
