### PR TITLE
Browse link switching and plan overflow fix

### DIFF
--- a/public/js/controllers/home-controller.js
+++ b/public/js/controllers/home-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var app = angular.module("HomeController", ['PlanService', 'NotificationService', 'EditPlanDetailsModal']);
+var app = angular.module("HomeController", ['PlanService', 'NotificationService', 'AuthService', 'EditPlanDetailsModal']);
 
-app.controller('homeController', ['$scope','$http', 'planService', 'notificationService', 'user', 'editPlanDetailsModal',
-function($scope, $http, planService, notificationService, user, editPlanDetailsModal) {
+app.controller('homeController', ['$scope','$http', 'planService', 'notificationService', 'user', 'authService', 'editPlanDetailsModal',
+function($scope, $http, planService, notificationService, user, authService, editPlanDetailsModal) {
     $scope.user = user;
     notificationService.on('user-changed', function(user){
         $scope.user = user;
@@ -22,5 +22,7 @@ function($scope, $http, planService, notificationService, user, editPlanDetailsM
     $scope.editPlanDetails = function() {
         editPlanDetailsModal.open($scope.plan);
     };
+
+    scope.isAuthenticated = authService.isAuthenticated;
 
 }]);

--- a/public/js/controllers/home-controller.js
+++ b/public/js/controllers/home-controller.js
@@ -23,6 +23,6 @@ function($scope, $http, planService, notificationService, user, authService, edi
         editPlanDetailsModal.open($scope.plan);
     };
 
-    scope.isAuthenticated = authService.isAuthenticated;
+    $scope.isAuthenticated = authService.isAuthenticated;
 
 }]);

--- a/public/sass/browse.scss
+++ b/public/sass/browse.scss
@@ -35,3 +35,7 @@
     margin-bottom: 10px;
   }
 }
+
+.open-plan-preview {
+  overflow-x: scroll;
+}

--- a/public/views/browse.html
+++ b/public/views/browse.html
@@ -33,7 +33,7 @@
                     <button class="btn btn-default btn-sm load-btn" ng-click="load(plan)"
                         ng-if="selectedPlan === plan">Load</button>
                 </div>
-                <div class="panel-body" ng-if="selectedPlan === plan">
+                <div class="panel-body open-plan-preview" ng-if="selectedPlan === plan">
                     <years plan="::selectedPlan" readonly="true"></years>
                 </div>
             </div>

--- a/public/views/empty-view.html
+++ b/public/views/empty-view.html
@@ -1,4 +1,7 @@
-<div class="container" id="empty-view">
+<div class="container" id="empty-view" ng-switch="isAuthenticated()">
     <h3>To get started, click "Add Year" below.</h3>
-    <h3>If you log in, you can <a href="/browse"><b>Browse</b></a> and select someone else's shared plan.</h3>
+    <h3>If you log in, you can
+        <a ng-switch-when="true" href="/browse"><b>Browse</b></a>
+        <span ng-switch-default>browse</span>
+        and select someone else's shared plan.</h3>
 </div>

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -1,7 +1,8 @@
 <div class="home">
     <navbar user="user"></navbar>
     <div class="content">
-        <h3 class="plan-title" ng-click="editPlanDetails()">{{plan.title}}</h3>
+        <h3 class="plan-title" ng-click="editPlanDetails()" style="cursor:pointer;">
+            {{plan.title}}<i class="fa fa-pencil fa-fw" aria-hidden="true"></i></h3>
         <!-- Display for when there are no years -->
         <div ng-if="plan.years.length === 0" ng-include="'views/empty-view.html'"></div>
 


### PR DESCRIPTION
Browse button is now linked when logged in and appears as normal text when not.
Added a possible fix for the safari plan browsing overflow bug but I couldn't test it. @akath20 you'll need to check that